### PR TITLE
fix: 修复分享到微信聊天时压缩图片方法createScaledBitmapWithRatio死循环

### DIFF
--- a/android/src/main/kotlin/com/jarvan/fluwx/io/ImagesIO.kt
+++ b/android/src/main/kotlin/com/jarvan/fluwx/io/ImagesIO.kt
@@ -85,7 +85,7 @@ class ImagesIOIml(override val image: WeChatFile) : ImagesIO {
                 result.recycle()
             }
             result = tmp
-            if (result.byteCount < maxLength) {
+            if (result.byteCount <= maxLength) {
                 break
             }
         }


### PR DESCRIPTION
修复分享到微信聊天窗口时，需要传分享icon，icon图片太大时会对图片进行压缩至32k以下，安卓上部分图片压缩时刚好到了最大长度，不满足break条件情况下会陷入死循环，导致分享接口没有响应
![image](https://user-images.githubusercontent.com/17864476/179991001-5889f357-d530-4ae1-bff1-35cf95fcdaa3.png)
